### PR TITLE
Add local model generator for web upscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 Este proyecto provee una demostración sencilla para aumentar la resolución de imágenes utilizando modelos ONNX directamente en el navegador. Todo el código es estático y puede desplegarse en GitHub Pages sin dependencias adicionales.
 
-## Uso
-1. Abrir `index.html` desde GitHub Pages o un servidor estático.
-2. Seleccionar una imagen y un modelo.
-3. Pulsar **Upscale** para procesar la imagen.
-4. Descargar el resultado en formato PNG si se desea.
+Los modelos se almacenan localmente en la carpeta `model/`. Para actualizar la lista de modelos basta con ejecutar `generate_models.py`, que generará el archivo `models.json` utilizado por la interfaz web.
 
-Los modelos disponibles se definen en `models.json` y se descargan dinámicamente desde sus URLs.
+## Uso
+1. Ejecuta `python generate_models.py` para actualizar `models.json` con los modelos presentes en la carpeta `model/`.
+2. Abre `index.html` desde GitHub Pages o cualquier servidor estático.
+3. Selecciona una imagen y el modelo deseado.
+4. Pulsa **Upscale** para procesar la imagen.
+5. Descarga el resultado en formato PNG si lo necesitas.
+
+Los modelos se cargan localmente desde la carpeta `model/` gracias al archivo `models.json` generado.

--- a/generate_models.py
+++ b/generate_models.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Utility to generate models.json from local model files."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping
+
+
+def generate_models(model_dir: Path = Path("model"), output: Path = Path("models.json")) -> Mapping[str, str]:
+    """Scan *model_dir* and write a JSON mapping to *output*.
+
+    Only files with extensions ``.onnx`` or ``.safetensors`` are included.
+    Returned mapping uses forward slashes for paths so it works on GitHub Pages.
+    """
+    mapping = {}
+    prefix = Path(model_dir).name
+    for path in sorted(model_dir.iterdir()):
+        if path.suffix.lower() not in {".onnx", ".safetensors"}:
+            continue
+        mapping[path.stem] = f"{prefix}/{path.name}"
+    output.write_text(json.dumps(mapping, indent=2, ensure_ascii=False))
+    return mapping
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="Generate models.json")
+    parser.add_argument("--model-dir", default="model", help="Directory with model files")
+    parser.add_argument("--output", default="models.json", help="Path for generated JSON")
+    args = parser.parse_args(argv)
+
+    generate_models(Path(args.model_dir), Path(args.output))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/index.html
+++ b/index.html
@@ -4,16 +4,7 @@
 <meta charset="UTF-8">
 <title>Upscaler IA</title>
 <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
-<style>
-body {font-family: Arial, sans-serif; margin: 20px;}
-#preview-area {display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px;}
-canvas {border: 1px solid #ccc; max-width: 100%; height: auto;}
-button {margin-right: 10px;}
-#progress.hidden {display: none;}
-#progress::before {content: '⏳'; display: inline-block; margin-right: 5px; animation: spin 1s linear infinite;}
-@keyframes spin {from {transform: rotate(0deg);} to {transform: rotate(360deg);}}
-@media (max-width: 600px) {#preview-area {flex-direction: column;}}
-</style>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 <h1>Upscaler IA en el Navegador</h1>

--- a/models.json
+++ b/models.json
@@ -1,4 +1,4 @@
 {
-  "AnimeSharp 2x": "https://github.com/Kim2091/Kim2091-Models/releases/download/2x-AnimeSharpV4/2x-AnimeSharpV4_RCAN_fp16_op17.onnx",
-  "AnimeSharp 4x": "https://github.com/Kim2091/Kim2091-Models/releases/download/4x-AnimeSharpV4/4x-AnimeSharpV4_RCAN_fp16_op17.onnx"
+  "2x-AnimeSharpV4_RCAN_fp16_op17": "model/2x-AnimeSharpV4_RCAN_fp16_op17.onnx"
 }
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,8 @@
+body {font-family: Arial, sans-serif; margin: 20px;}
+#preview-area {display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px;}
+canvas {border: 1px solid #ccc; max-width: 100%; height: auto;}
+button {margin-right: 10px;}
+#progress.hidden {display: none;}
+#progress::before {content: '⏳'; display: inline-block; margin-right: 5px; animation: spin 1s linear infinite;}
+@keyframes spin {from {transform: rotate(0deg);} to {transform: rotate(360deg);}}
+@media (max-width: 600px) {#preview-area {flex-direction: column;}}

--- a/tests/test_generate_models.py
+++ b/tests/test_generate_models.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+from generate_models import generate_models
+
+
+def test_generate_models(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "one.onnx").write_text("x")
+    (model_dir / "two.safetensors").write_text("x")
+    output = tmp_path / "models.json"
+    mapping = generate_models(model_dir, output)
+    assert output.exists()
+    data = json.loads(output.read_text())
+    expected = {
+        "one": "model/one.onnx",
+        "two": "model/two.safetensors",
+    }
+    assert mapping == expected
+    assert data == expected
+


### PR DESCRIPTION
## Summary
- add a `generate_models.py` script to create `models.json` from local model files
- reference the script in README and update usage instructions
- split CSS into a new `style.css` file
- update `index.html` to load the stylesheet
- include a test for the generator

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4580cdd88329ac3166a8c8842dbc