### PR TITLE
Implement Node model generator and layout fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Upscaler IA en el navegador
 
-Este proyecto provee una demostración sencilla para aumentar la resolución de imágenes utilizando modelos ONNX directamente en el navegador. Todo el código es estático y puede desplegarse en GitHub Pages sin dependencias adicionales.
+Este proyecto demuestra cómo aumentar la resolución de imágenes utilizando modelos ONNX directamente en el navegador. Todo el código es estático y puede desplegarse en GitHub Pages sin depender de un servidor.
 
-Los modelos se almacenan localmente en la carpeta `model/`. Para actualizar la lista de modelos basta con ejecutar `generate_models.py`, que generará el archivo `models.json` utilizado por la interfaz web.
+Los modelos se almacenan localmente en la carpeta `model/`. Para actualizar la lista de modelos se provee el script `gen-models-json.js`, que genera el archivo `models.json` utilizado por la interfaz web.
 
 ## Uso
-1. Ejecuta `python generate_models.py` para actualizar `models.json` con los modelos presentes en la carpeta `model/`.
+1. Ejecuta `node gen-models-json.js` para actualizar `models.json` con los modelos presentes en la carpeta `model/`.
 2. Abre `index.html` desde GitHub Pages o cualquier servidor estático.
 3. Selecciona una imagen y el modelo deseado.
 4. Pulsa **Upscale** para procesar la imagen.

--- a/gen-models-json.js
+++ b/gen-models-json.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function generateModels(modelDir = path.join(__dirname, 'model'), output = path.join(__dirname, 'models.json')) {
+  const mapping = {};
+  const prefix = path.basename(modelDir);
+  if (!fs.existsSync(modelDir)) {
+    fs.writeFileSync(output, JSON.stringify(mapping, null, 2) + '\n');
+    return mapping;
+  }
+  for (const file of fs.readdirSync(modelDir)) {
+    const ext = path.extname(file).toLowerCase();
+    if (ext !== '.onnx' && ext !== '.safetensors') continue;
+    const name = path.basename(file, ext);
+    mapping[name] = `${prefix}/${file}`;
+  }
+  fs.writeFileSync(output, JSON.stringify(mapping, null, 2) + '\n');
+  return mapping;
+}
+
+if (require.main === module) {
+  const [, , modelDirArg, outputArg] = process.argv;
+  generateModels(modelDirArg ? path.resolve(modelDirArg) : path.join(__dirname, 'model'),
+                 outputArg ? path.resolve(outputArg) : path.join(__dirname, 'models.json'));
+}
+
+module.exports = generateModels;

--- a/models.json
+++ b/models.json
@@ -1,4 +1,3 @@
 {
   "2x-AnimeSharpV4_RCAN_fp16_op17": "model/2x-AnimeSharpV4_RCAN_fp16_op17.onnx"
 }
-

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 body {font-family: Arial, sans-serif; margin: 20px;}
 #preview-area {display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px;}
-canvas {border: 1px solid #ccc; max-width: 100%; height: auto;}
+canvas {border: 1px solid #ccc; max-width: 100%; max-height: 400px; width: auto; height: auto; object-fit: contain;}
 button {margin-right: 10px;}
 #progress.hidden {display: none;}
 #progress::before {content: '⏳'; display: inline-block; margin-right: 5px; animation: spin 1s linear infinite;}
-@keyframes spin {from {transform: rotate(0deg);} to {transform: rotate(360deg);}}
+@keyframes spin {from {transform: rotate(0deg);} to {transform: rotate(360deg);} }
 @media (max-width: 600px) {#preview-area {flex-direction: column;}}


### PR DESCRIPTION
## Summary
- add Node script `gen-models-json.js` to generate `models.json`
- document the new script and usage in `README.md`
- ensure canvas elements don't break the layout
- keep generated `models.json` up to date

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d4b765ee48329bf84969f5a63593d